### PR TITLE
Signal trap replacement in lib/ffi/pcap/capture_wrapper.rb

### DIFF
--- a/lib/ffi/pcap/capture_wrapper.rb
+++ b/lib/ffi/pcap/capture_wrapper.rb
@@ -42,20 +42,17 @@ module FFI
       def initialize(pcap, opts={}, &block)
         @handler = opts.fetch(handler,CopyHandler)
 
-        trap('INT') do
-          stop()
-          close()
-
-          raise(SignalException,'INT',caller)
+        at_exit do
+          begin
+            stop()
+            close()
+          rescue NoDeviceError
+          rescue NullPointerError
+            # Indicates the device has already been stopped and closed
+            # Therefore there's nothing to do.
+          end
         end
-
-        trap('TERM') do
-          stop()
-          close()
-
-          raise(SignalException,'TERM',caller)
-        end
-
+        
         super(pcap, opts, &block)
       end
 

--- a/lib/ffi/pcap/common_wrapper.rb
+++ b/lib/ffi/pcap/common_wrapper.rb
@@ -161,7 +161,7 @@ module FFI
       #
       def _check_pcap
         if @pcap.nil?
-          raise(StandardError,"nil pcap device",caller)
+          raise(NoDeviceError,"nil pcap device",caller)
         else
           @pcap
         end
@@ -179,7 +179,7 @@ module FFI
         ptr = _check_pcap
 
         if ptr.null?
-          raise(StandardError,"null pointer to pcap device",caller)
+          raise(NullPointerError,"null pointer to pcap device",caller)
         else
           ptr
         end

--- a/lib/ffi/pcap/exceptions.rb
+++ b/lib/ffi/pcap/exceptions.rb
@@ -15,6 +15,16 @@ module FFI
     end
 
     #
+    # A {NoDeviceError} indicates a pcap device that has already
+    # been stopped and closed
+    #
+    class NoDeviceError < StandardError
+    end
+    
+    class NullPointerError < StandardError
+    end
+
+    #
     # A {ReadError} is a sub-class of {LibError} that
     # indicates a problem reading from a pcap device.
     #

--- a/lib/ffi/pcap/exceptions.rb
+++ b/lib/ffi/pcap/exceptions.rb
@@ -20,7 +20,11 @@ module FFI
     #
     class NoDeviceError < StandardError
     end
-    
+
+    #
+    # A {NullPointerError} indicates a pcap device that doesn't
+    # have a pointer assigned to it
+    #
     class NullPointerError < StandardError
     end
 


### PR DESCRIPTION
Previously, the CaptureWrapper#initialize method defined signal traps for INT and TERM which meant that the most recently initialized capture_wrapper object would be the one to handle those signals. 

This caused some weird behavior when sending a TERM to the overall app that implemented capture wrappers when a pcap device had already been closed since it would throw a standard error when handling the TERM signal.

I'm not sure if this is even actively developed anymore (been 2 years since the last release), but I figured I'd throw it out there for the heck of it. Let me know what you think.

All the specs pass except for the FileHeader specs which fail due to IndexErrors both in cloned master and my branch. I'm not sure how to fix it exactly, and suspect its environmental... Error output below:

``` ruby
  1) FFI::PCap::FileHeader should parse a pcap file correctly
     Failure/Error: described_class.new(:raw => File.read(PCAP_TESTFILE))
     IndexError:
       Memory access offset=0 size=875 is out of bounds
     # ./spec/file_header_spec.rb:5:in `new'
     # ./spec/file_header_spec.rb:5:in `block (2 levels) in <top (required)>'
     # ./spec/file_header_spec.rb:9:in `block (2 levels) in <top (required)>'
```
