### PR TITLE
function "activate" should be "pcap_activate"

### DIFF
--- a/lib/ffi/pcap/pcap.rb
+++ b/lib/ffi/pcap/pcap.rb
@@ -304,6 +304,6 @@ module FFI
     attach_optional_function :pcap_can_set_rfmon, [:pcap_t, :int], :int
     attach_optional_function :pcap_set_timeout, [:pcap_t, :int], :int
     attach_optional_function :pcap_set_buffer_size, [:pcap_t, :int], :int
-    attach_optional_function :activate, [:pcap_t], :int
+    attach_optional_function :pcap_activate, [:pcap_t], :int
   end
 end


### PR DESCRIPTION
calling FFI::Pcap::activate doesn't work, because the function is called "pcap_activate" in libpcap
see http://www.tcpdump.org/manpages/pcap_activate.3pcap.html
