### PR TITLE
Fix pcap_can_set_rfmon and add pcap_set_rfmon

### DIFF
--- a/lib/ffi/pcap/pcap.rb
+++ b/lib/ffi/pcap/pcap.rb
@@ -301,7 +301,8 @@ module FFI
     attach_optional_function :pcap_create, [:string, :pointer], :pcap_t
     attach_optional_function :pcap_set_snaplen, [:pcap_t, :int], :int
     attach_optional_function :pcap_set_promisc, [:pcap_t, :int], :int
-    attach_optional_function :pcap_can_set_rfmon, [:pcap_t, :int], :int
+    attach_optional_function :pcap_can_set_rfmon, [:pcap_t], :int
+    attach_optional_function :pcap_set_rfmon, [:pcap_t, :int], :int
     attach_optional_function :pcap_set_timeout, [:pcap_t, :int], :int
     attach_optional_function :pcap_set_buffer_size, [:pcap_t, :int], :int
     attach_optional_function :activate, [:pcap_t], :int


### PR DESCRIPTION
`pcap_can_set_rfmon` has only one argument (see: http://www.tcpdump.org/manpages/pcap_can_set_rfmon.3pcap.html)
I've also added `pcap_set_rfmon` to actually set monitoring mode (see: http://www.tcpdump.org/manpages/pcap_set_rfmon.3pcap.html)
